### PR TITLE
Fix queue intersection/conflict

### DIFF
--- a/src/backend/modules/applications/index.ts
+++ b/src/backend/modules/applications/index.ts
@@ -52,7 +52,7 @@ async function repostDeletedApplicationThreads() {
     }
 }
 
-makeWorker("tcn:repost-deleted-application-threads", repostDeletedApplicationThreads);
+makeWorker("repost-deleted-application-threads", repostDeletedApplicationThreads);
 
 loop("full-trigger-repost-deleted-application-threads", async () => repostDeletedApplicationThreadsQueue.add("", null), 300000);
 bot.on(Events.ThreadDelete, (thread) => void (thread.parent === channels.applicants && repostDeletedApplicationThreadsQueue.add("", null)));

--- a/src/backend/modules/global/index.ts
+++ b/src/backend/modules/global/index.ts
@@ -489,7 +489,7 @@ globalBot.on(Events.MessageUpdate, async (before, after) => {
     });
 });
 
-makeWorker<GlobalChatRelayTask>("tcn:global-chat-relay", async (data) => {
+makeWorker<GlobalChatRelayTask>("global-chat-relay", async (data) => {
     if (data.type === "post") {
         const message = await db.query.globalMessages.findFirst({ where: eq(tables.globalMessages.id, data.id) });
 

--- a/src/backend/modules/polls/index.ts
+++ b/src/backend/modules/polls/index.ts
@@ -52,7 +52,7 @@ loop(
     10000,
 );
 
-makeWorker<DMReminderTask>("tcn:dm-reminders", async ({ id, url, user }) => {
+makeWorker<DMReminderTask>("dm-reminders", async ({ id, url, user }) => {
     const link = `[poll #${id}](<${url}>)`;
 
     try {
@@ -268,7 +268,7 @@ async function repostDeletedOpenPolls() {
     }
 }
 
-makeWorker("tcn:repost-deleted-open-polls", repostDeletedOpenPolls);
+makeWorker("repost-deleted-open-polls", repostDeletedOpenPolls);
 
 loop("full-trigger-repost-deleted-open-polls", async () => repostDeletedOpenPollsQueue.add("", null), 300000);
 bot.on(Events.MessageDelete, (message) => void (message.channel === channels.voteHere && repostDeletedOpenPollsQueue.add("", null)));

--- a/src/backend/modules/reports/index.ts
+++ b/src/backend/modules/reports/index.ts
@@ -84,7 +84,7 @@ bot.on(Events.MessageDelete, async (message) => {
     await updateReportsDashboard();
 });
 
-makeWorker<ReportPublishTask>("tcn:report-publish", async ({ id, guild }) => {
+makeWorker<ReportPublishTask>("report-publish", async ({ id, guild }) => {
     const report = await db.query.networkUserReports.findFirst({
         columns: { id: true, status: true, category: true },
         where: eq(tables.networkUserReports.id, id),
@@ -146,7 +146,7 @@ makeWorker<ReportPublishTask>("tcn:report-publish", async ({ id, guild }) => {
     await reportActionQueue.add("", null);
 });
 
-makeWorker("tcn:report-action", async () => {
+makeWorker("report-action", async () => {
     while (true) {
         const [task] = await db
             .select({
@@ -302,7 +302,7 @@ makeWorker("tcn:report-action", async () => {
     }
 });
 
-makeWorker<ReportRescindTask>("tcn:report-rescind", async ({ id, explanation, ...data }) => {
+makeWorker<ReportRescindTask>("report-rescind", async ({ id, explanation, ...data }) => {
     const settings = await db.query.reportSettings.findFirst({
         columns: { channel: true },
         where: eq(tables.reportSettings.guild, data.guild),

--- a/src/backend/modules/rolesync/index.ts
+++ b/src/backend/modules/rolesync/index.ts
@@ -98,7 +98,7 @@ async function fixRoles(guild: { id: string; roleColor: number; roleName: string
     });
 }
 
-makeWorker<string>("tcn:fix-guild-roles", async (id) => {
+makeWorker<string>("fix-guild-roles", async (id) => {
     const guild = await db.query.guilds.findFirst({
         columns: { id: true, roleColor: true, roleName: true, hqRole: true, hubRole: true, owner: true, advisor: true },
         where: eq(tables.guilds.id, id),
@@ -107,7 +107,7 @@ makeWorker<string>("tcn:fix-guild-roles", async (id) => {
     if (guild) await fixRoles(guild);
 });
 
-makeWorker<string>("tcn:fix-user-roles", async (id) => {
+makeWorker<string>("fix-user-roles", async (id) => {
     const hqMember = await HQ.members.fetch(id).catch(() => null);
     const hubMember = await HUB.members.fetch(id).catch(() => null);
 

--- a/src/backend/modules/staffsync/index.ts
+++ b/src/backend/modules/staffsync/index.ts
@@ -6,7 +6,7 @@ import tables from "../../db/tables.js";
 import { loop } from "../../lib/loop.js";
 import { FixUserStaffStatusTask, fixGuildStaffStatusQueue, fixUserRolesQueue, fixUserStaffStatusQueue, makeWorker } from "../../queue.js";
 
-makeWorker<FixUserStaffStatusTask>("tcn:fix-user-staff-status", async ({ guild, user }) => {
+makeWorker<FixUserStaffStatusTask>("fix-user-staff-status", async ({ guild, user }) => {
     const isStaff = !!(await db.query.guildStaff.findFirst({ where: and(eq(tables.guildStaff.guild, guild), eq(tables.guildStaff.user, user)) }));
 
     const force = await db.query.forcedStaff.findFirst({
@@ -36,7 +36,7 @@ makeWorker<FixUserStaffStatusTask>("tcn:fix-user-staff-status", async ({ guild, 
     await fixUserRolesQueue.add("", user);
 });
 
-makeWorker<string>("tcn:fix-guild-staff-status", async (guild) => {
+makeWorker<string>("fix-guild-staff-status", async (guild) => {
     const obj = await bot.guilds.fetch(guild);
     await obj.roles.fetch();
     await obj.members.fetch();

--- a/src/backend/queue.ts
+++ b/src/backend/queue.ts
@@ -22,26 +22,26 @@ export type GlobalChatRelayTask =
 export const queues = new Map<string, Queue<unknown>>();
 
 function createQueue<T>(name: string) {
-    const queue = new Queue<T>(name, qoptions);
+    const queue = new Queue<T>(`${process.env.QUEUE_PREFIX}:${name}`, qoptions);
     queues.set(name, queue);
     return queue;
 }
 
-export const dmReminderQueue = createQueue<DMReminderTask>("tcn:dm-reminders");
-export const repostDeletedApplicationThreadsQueue = createQueue("tcn:repost-deleted-application-threads");
-export const repostDeletedOpenPollsQueue = createQueue("tcn:repost-deleted-open-polls");
-export const fixGuildRolesQueue = createQueue<string>("tcn:fix-guild-roles");
-export const fixUserRolesQueue = createQueue<string>("tcn:fix-user-roles");
-export const fixUserStaffStatusQueue = createQueue<FixUserStaffStatusTask>("tcn:fix-user-staff-status");
-export const fixGuildStaffStatusQueue = createQueue<string>("tcn:fix-guild-staff-status");
-export const reportPublishQueue = createQueue<ReportPublishTask>("tcn:report-publish");
-export const reportActionQueue = createQueue<null>("tcn:report-action");
-export const reportRescindQueue = createQueue<ReportRescindTask>("tcn:report-rescind");
-export const globalChatRelayQueue = createQueue<GlobalChatRelayTask>("tcn:global-chat-relay");
+export const dmReminderQueue = createQueue<DMReminderTask>("dm-reminders");
+export const repostDeletedApplicationThreadsQueue = createQueue("repost-deleted-application-threads");
+export const repostDeletedOpenPollsQueue = createQueue("repost-deleted-open-polls");
+export const fixGuildRolesQueue = createQueue<string>("fix-guild-roles");
+export const fixUserRolesQueue = createQueue<string>("fix-user-roles");
+export const fixUserStaffStatusQueue = createQueue<FixUserStaffStatusTask>("fix-user-staff-status");
+export const fixGuildStaffStatusQueue = createQueue<string>("fix-guild-staff-status");
+export const reportPublishQueue = createQueue<ReportPublishTask>("report-publish");
+export const reportActionQueue = createQueue<null>("report-action");
+export const reportRescindQueue = createQueue<ReportRescindTask>("report-rescind");
+export const globalChatRelayQueue = createQueue<GlobalChatRelayTask>("global-chat-relay");
 
 export function makeWorker<T>(name: string, handler: (data: T) => unknown) {
     new Worker<T>(
-        name,
+        `${process.env.QUEUE_PREFIX}:${name}`,
         async ({ data }) => {
             await trackMetrics(`worker:${name}`, async () => {
                 try {


### PR DESCRIPTION
Running multiple copies of the bot will cause the queues to conflict; that is, tasks inserted by one bot may be consumed by the other. By adding a `QUEUE_PREFIX` environment variable, this is fixed by having the queues named differently per instance, specifically between the production and development deployments.