### PR TITLE
Enable message linking across servers in global chat

### DIFF
--- a/src/backend/modules/commands/global.ts
+++ b/src/backend/modules/commands/global.ts
@@ -498,7 +498,7 @@ export async function handleGlobal(interaction: ChatInputCommandInteraction) {
             allowedMentions: { roles: [process.env.ROLE_OBSERVERS!] },
         });
 
-        for (const job of await globalChatRelayQueue.getJobs()) if (["post", "start-edit", "edit"].includes(job.data.type)) await job.remove();
+        for (const job of await globalChatRelayQueue.getJobs()) if (["post", "edit", "edit"].includes(job.data.type)) await job.remove();
 
         await res.editReply(template.ok("This channel is now in panic mode. Observers have been alerted. You may continue deleting messages."));
 

--- a/src/backend/modules/global/lib.ts
+++ b/src/backend/modules/global/lib.ts
@@ -1,0 +1,48 @@
+import { eq } from "drizzle-orm";
+import { alias } from "drizzle-orm/mysql-core";
+import { db } from "../../db/db.js";
+import tables from "../../db/tables.js";
+import { trackMetrics } from "../../lib/metrics.js";
+
+export async function augmentGlobalMessageContent(content: string, guilds: string[]): Promise<Map<string, string>> {
+    const results = new Map<string, string>();
+    const messageInstances = new Map<string, Map<string, string>>();
+
+    await trackMetrics("global:relay:find-instances", async () => {
+        for (const match of content.matchAll(/https:\/\/(\w+\.)?discord\.com\/channels\/\d+\/\d+\/(\d+)/g))
+            try {
+                const id = match[2];
+                if (messageInstances.has(id)) return;
+
+                const source = alias(tables.globalMessageInstances, "source");
+
+                const instances = await db
+                    .select({
+                        guild: tables.globalMessageInstances.guild,
+                        channel: tables.globalMessageInstances.channel,
+                        message: tables.globalMessageInstances.message,
+                    })
+                    .from(tables.globalMessageInstances)
+                    .innerJoin(source, eq(tables.globalMessageInstances.ref, source.ref))
+                    .where(eq(source.message, id));
+
+                messageInstances.set(
+                    id,
+                    new Map(
+                        instances.map((instance) => [instance.guild, `https://discord.com/channels/${instance.guild}/${instance.channel}/${instance.message}`]),
+                    ),
+                );
+            } catch {}
+    });
+
+    for (const guild of guilds)
+        results.set(
+            guild,
+            content.replaceAll(/https:\/\/(\w+\.)?discord\.com\/channels\/\d+\/\d+\/\d+/g, (match) => {
+                const id = match.split("/").at(-1)!;
+                return messageInstances.get(id)?.get(guild) ?? match;
+            }),
+        );
+
+    return results;
+}

--- a/src/backend/queue.ts
+++ b/src/backend/queue.ts
@@ -15,8 +15,7 @@ export type GlobalChatRelayTask =
     | { type: "post"; id: number; locations: { guild: string; location: string }[] }
     | { type: "start-delete"; objects: { ref: number; guild: string; channel: string; message: string }[] }
     | { type: "delete"; guild: string; channel: string; messages: string[] }
-    | { type: "start-edit"; ref: number; guild: string; channel: string; message: string; content?: string; embeds?: any; attachments: any }
-    | { type: "edit"; ref: number; guild: string; channel: string; message: string }
+    | { type: "edit"; ref: number; guild: string; channel: string; message: string; content?: string; embeds?: any; attachments: any }
     | { type: "start-info-on-user"; ref: number };
 
 export const queues = new Map<string, Queue<unknown>>();


### PR DESCRIPTION
This feature allows linking messages directly in global chat. If the message is a global chat message, then the bot will attempt to change the link to point to the target server in all copies of the message. This works for editing as well (which has also been upgraded to run in parallel for increased speed).