### PR TITLE
Fix editing replies removing their prefix

### DIFF
--- a/src/backend/modules/global/lib.ts
+++ b/src/backend/modules/global/lib.ts
@@ -4,12 +4,44 @@ import { db } from "../../db/db.js";
 import tables from "../../db/tables.js";
 import { trackMetrics } from "../../lib/metrics.js";
 
-export async function augmentGlobalMessageContent(content: string, guilds: string[]): Promise<Map<string, string>> {
+type Message = Exclude<Awaited<ReturnType<typeof db.query.globalMessages.findFirst>>, undefined>;
+
+export async function augmentGlobalMessageContent(message: Message, guilds: string[]): Promise<Map<string, string>> {
     const results = new Map<string, string>();
+
+    const prefixes = new Map<string, string>();
+
+    if (message.replyTo !== null) {
+        await trackMetrics("global:relay:get-references", async () => {
+            const references = await db
+                .select({
+                    replyUsername: tables.globalMessages.replyUsername,
+                    guild: tables.globalMessageInstances.guild,
+                    channel: tables.globalMessageInstances.channel,
+                    message: tables.globalMessageInstances.message,
+                })
+                .from(tables.globalMessages)
+                .leftJoin(tables.globalMessageInstances, eq(tables.globalMessages.id, tables.globalMessageInstances.ref))
+                .where(eq(tables.globalMessages.id, message.replyTo!));
+
+            if (references[0].guild)
+                for (const reference of references) {
+                    if (reference.guild === message.originGuild) continue;
+
+                    prefixes.set(
+                        reference.guild!,
+                        `${process.env.EMOJI_GLOBAL_REPLY} ${reference.replyUsername ? `${reference.replyUsername}: ` : ""}https://discord.com/channels/${
+                            reference.guild
+                        }/${reference.channel}/${reference.message}\n`,
+                    );
+                }
+        });
+    }
+
     const messageInstances = new Map<string, Map<string, string>>();
 
     await trackMetrics("global:relay:find-instances", async () => {
-        for (const match of content.matchAll(/https:\/\/(\w+\.)?discord\.com\/channels\/\d+\/\d+\/(\d+)/g))
+        for (const match of message.content.matchAll(/https:\/\/(\w+\.)?discord\.com\/channels\/\d+\/\d+\/(\d+)/g))
             try {
                 const id = match[2];
                 if (messageInstances.has(id)) return;
@@ -38,10 +70,12 @@ export async function augmentGlobalMessageContent(content: string, guilds: strin
     for (const guild of guilds)
         results.set(
             guild,
-            content.replaceAll(/https:\/\/(\w+\.)?discord\.com\/channels\/\d+\/\d+\/\d+/g, (match) => {
+            `${
+                message.replyTo === null ? "" : prefixes.get(guild) ?? `${process.env.EMOJI_GLOBAL_REPLY} **[original not found]**\n`
+            }${message.content.replaceAll(/https:\/\/(\w+\.)?discord\.com\/channels\/\d+\/\d+\/\d+/g, (match) => {
                 const id = match.split("/").at(-1)!;
                 return messageInstances.get(id)?.get(guild) ?? match;
-            }),
+            })}`,
         );
 
     return results;


### PR DESCRIPTION
Editing replies right now will cause the reply prefix to be removed from copies of the message. This finally moves all message augmentation logic into a utility function which is now called by both the send relay and edit relay.