### PR TITLE
Add guild ID to application posts

### DIFF
--- a/src/backend/lib/applications.ts
+++ b/src/backend/lib/applications.ts
@@ -43,7 +43,7 @@ export async function createApplicationThread(
         return await channels.applicants.threads.create({
             name: name.slice(0, 80),
             message: {
-                content: `${invite}`,
+                content: `${invite} — \`${guild.id}\``,
                 embeds: [
                     {
                         title: "New Application",


### PR DESCRIPTION
This PR adds the guild ID to the content of application posts so users will find the thread when searching for the server ID.