### PR TITLE
Change page link to discord link

### DIFF
--- a/src/web/app/(home)/partners/client.tsx
+++ b/src/web/app/(home)/partners/client.tsx
@@ -91,7 +91,7 @@ export default function PartnersClient({ servers }: { servers: { id: string; mas
                                 <Panel key={id} className="flex items-center gap-8">
                                     <Image className="rounded-full" src={image} alt={`${name} Icon`} width={100} height={100} />
                                     <div className="flex flex-col gap-2">
-                                        <a href={`/server/${id}`} className="link text-xl font-semibold">
+                                        <a href={`https://discord.gg/${invite}`} target="_blank" className="link text-xl font-semibold">
                                             {name}
                                         </a>
                                         <a href={`https://discord.gg/${invite}`} target="_blank">


### PR DESCRIPTION
# Description
Clicking a server name opens its Discord invite in a new tab like the Join button does, instead of trying to open a page that doesn't exist.

# Additional Information
Technically I cannot actually test that it works (see the README in the base repository for why), but it's just replacing a URL, so yeah.